### PR TITLE
Add publish and send overloads with options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ autom4te.cache/
 tarballs/
 test-results/
 Thumbs.db
+.vs/
 
 # Mac bundle stuff
 *.dmg

--- a/MessageTransports/RockyBus.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/MessageTransports/RockyBus.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -40,13 +40,32 @@ namespace RockyBus
         public Task InitializeReceivingEndpoint() => azureServiceBusManagement.InitializeReceivingEndpoint(TopicName, ReceivingMessageTypeNames.ReceivingEventMessageTypeNames);
 
         public Task Publish<T>(T message, string messageTypeName) => SendToTopic(message, messageTypeName);
-        public Task Send<T>(T message, string messageTypeName) => SendToTopic(message, messageTypeName, true);
 
-        private Task SendToTopic<T>(T message, string messageTypeName, bool isCommand = false)
+        public Task Publish<T>(T message, string messageTypeName, PublishOptions publishOptions) => SendToTopic(message, messageTypeName, publishOptions);
+
+        public Task Send<T>(T message, string messageTypeName) => SendToTopic(message, messageTypeName, isCommand: true);
+
+        public Task Send<T>(T message, string messageTypeName, SendOptions sendOptions) => SendToTopic(message, messageTypeName, sendOptions, true);
+
+        private Task SendToTopic<T>(T message, string messageTypeName, Options options = null, bool isCommand = false)
         {
             var serviceBusMessage = new ServiceBusMessage { Body = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)) };
+
             serviceBusMessage.UserProperties.Add(UserProperties.MessageTypeKey, messageTypeName);
-            if (isCommand) serviceBusMessage.UserProperties.Add(UserProperties.DestinationQueueKey, configuration.PublishAndSendOptions.GetQueue<T>());
+
+            if (options != null)
+            {
+                foreach (var item in options.GetHeaders())
+                {
+                    serviceBusMessage.UserProperties.Add(item.Key, item.Value);
+                }
+            }
+
+            if (isCommand)
+            {
+                serviceBusMessage.UserProperties.Add(UserProperties.DestinationQueueKey, configuration.PublishAndSendOptions.GetQueue<T>());
+            }
+
             return topicClient.SendAsync(serviceBusMessage);
         }
 

--- a/RockyBus.Abstractions/IBus.cs
+++ b/RockyBus.Abstractions/IBus.cs
@@ -6,7 +6,9 @@ namespace RockyBus
     {
         Task Start();
         Task Publish<T>(T eventMessage);
+        Task Publish<T>(T eventMessage, PublishOptions options);
         Task Send<T>(T commandMessage);
+        Task Send<T>(T commandMessage, SendOptions options);
         Task Stop();
     }
 }

--- a/RockyBus.Abstractions/Options.cs
+++ b/RockyBus.Abstractions/Options.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace RockyBus
+{
+    public abstract class Options
+    {
+        protected Options()
+        {
+            Headers = new Dictionary<string, string>();
+        }
+
+        public Dictionary<string, string> Headers { get; }
+    }
+}

--- a/RockyBus.Abstractions/PublishOptions.cs
+++ b/RockyBus.Abstractions/PublishOptions.cs
@@ -1,0 +1,6 @@
+namespace RockyBus
+{
+    public class PublishOptions : Options
+    {
+    }
+}

--- a/RockyBus.Abstractions/SendOptions.cs
+++ b/RockyBus.Abstractions/SendOptions.cs
@@ -1,0 +1,6 @@
+namespace RockyBus
+{
+    public class SendOptions : Options
+    {
+    }
+}

--- a/RockyBus.UnitTests/BusTests.cs
+++ b/RockyBus.UnitTests/BusTests.cs
@@ -97,5 +97,33 @@ namespace RockyBus.UnitTests
             await messageTransport.ReceivedWithAnyArgs().InitializeReceivingEndpoint();
             await messageTransport.ReceivedWithAnyArgs().StartReceivingMessages(Arg.Any<MessageHandlerExecutor>());
         }
+
+        [TestMethod]
+        public async Task send_a_message_with_send_options_should_send_a_command_to_the_message_transport()
+        {
+            await bus.Start();
+            var message = new AppleCommand();
+            var options = new SendOptions();
+
+            options.SetHeaders("color", "red");
+            options.SetHeaders("dents", "4");
+
+            await bus.Send(message, options);
+            await messageTransport.Received().Send(message, bus.MessageTypeToNameSendingCommandMap[message.GetType()], options);
+        }
+
+        [TestMethod]
+        public async Task publish_a_message_with_publish_options_should_send_a_command_to_the_message_transport()
+        {
+            await bus.Start();
+            var message = new CatEvent();
+            var options = new PublishOptions();
+
+            options.SetHeaders("name", "smokey");
+            options.SetHeaders("lives", "7");
+
+            await bus.Publish(message, options);
+            await messageTransport.Received().Publish(message, bus.MessageTypeToNamePublishingEventMap[message.GetType()], options);
+        }
     }
 }

--- a/RockyBus.UnitTests/PublishOptionsTests.cs
+++ b/RockyBus.UnitTests/PublishOptionsTests.cs
@@ -1,0 +1,56 @@
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RockyBus.UnitTests
+{
+    [TestClass]
+    public class PublishOptionsTests
+    {
+        [TestMethod]
+        public void ShouldSetOptions()
+        {
+            var sendOptions = new PublishOptions();
+            var key = "code";
+            var value = "abc"; 
+
+            sendOptions.SetHeaders(key, value);
+
+            sendOptions.Headers[key].Should().Be(value);
+        }
+
+        [TestMethod]
+        public void ShouldGetOptions()
+        {
+            var sendOptions = new PublishOptions();
+            var key = "code";
+            var value = "abc";
+            sendOptions.SetHeaders(key, value);
+
+            var options = sendOptions.GetHeaders();
+
+            options[key].Should().Be(value);
+        }
+
+        [TestMethod]
+        public void ShouldThrowIfOptionsAreNull()
+        {
+            Action setNullOptions = () => OptionExtensions.SetHeaders(null, "code", "value");
+            setNullOptions.ShouldThrow<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ShouldThrowIfKeyIsEmpty()
+        {
+            Action setNullOptions = () => OptionExtensions.SetHeaders(new SendOptions(), "", "value");
+            setNullOptions.ShouldThrow<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ShouldThrowIfKeyIsNull()
+        {
+            Action setNullOptions = () => OptionExtensions.SetHeaders(new SendOptions(), null, "value");
+            setNullOptions.ShouldThrow<ArgumentException>();
+        }
+    }
+}

--- a/RockyBus.UnitTests/SendOptionsTests.cs
+++ b/RockyBus.UnitTests/SendOptionsTests.cs
@@ -1,0 +1,56 @@
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RockyBus.UnitTests
+{
+    [TestClass]
+    public class SendOptionsTests
+    {
+        [TestMethod]
+        public void ShouldSetOptions()
+        {
+            var sendOptions = new SendOptions();
+            var key = "code";
+            var value = "abc"; 
+
+            sendOptions.SetHeaders(key, value);
+
+            sendOptions.Headers[key].Should().Be(value);
+        }
+
+        [TestMethod]
+        public void ShouldGetOptions()
+        {
+            var sendOptions = new SendOptions();
+            var key = "code";
+            var value = "abc";
+            sendOptions.SetHeaders(key, value);
+
+            var options = sendOptions.GetHeaders();
+
+            options[key].Should().Be(value);
+        }
+
+        [TestMethod]
+        public void ShouldThrowIfOptionsAreNull()
+        {
+            Action setNullOptions = () => OptionExtensions.SetHeaders(null, "code", "value");
+            setNullOptions.ShouldThrow<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ShouldThrowIfKeyIsEmpty()
+        {
+            Action setNullOptions = () => OptionExtensions.SetHeaders(new SendOptions(), "", "value");
+            setNullOptions.ShouldThrow<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ShouldThrowIfKeyIsNull()
+        {
+            Action setNullOptions = () => OptionExtensions.SetHeaders(new SendOptions(), null, "value");
+            setNullOptions.ShouldThrow<ArgumentException>();
+        }
+    }
+}

--- a/RockyBus/Bus.cs
+++ b/RockyBus/Bus.cs
@@ -24,18 +24,32 @@ namespace RockyBus
 
         public Task Publish<T>(T eventMessage)
         {
+            return Publish(eventMessage, null);
+        }
+
+        public Task Publish<T>(T eventMessage, PublishOptions options)
+        {
             if (!started) throw new InvalidOperationException("The bus has not been started.");
             var type = typeof(T);
             if (!busMessages.IsPublishable(type)) throw BusMessages.CreateMessageNotFoundException(type);
-            return busTransport.Publish(eventMessage, MessageTypeToNamePublishingEventMap[type]);
+            return options == null
+                ? busTransport.Publish(eventMessage, MessageTypeToNamePublishingEventMap[type])
+                : busTransport.Publish(eventMessage, MessageTypeToNamePublishingEventMap[type], options);
         }
 
         public Task Send<T>(T commandMessage)
         {
+            return Send(commandMessage, null);
+        }
+
+        public Task Send<T>(T commandMessage, SendOptions options)
+        {
             if (!started) throw new InvalidOperationException("The bus has not been started.");
             var type = typeof(T);
             if (!busMessages.IsSendable(type)) throw BusMessages.CreateMessageNotFoundException(type);
-            return busTransport.Send(commandMessage, MessageTypeToNameSendingCommandMap[type]);
+            return options == null
+                ? busTransport.Send(commandMessage, MessageTypeToNameSendingCommandMap[type])
+                : busTransport.Send(commandMessage, MessageTypeToNameSendingCommandMap[type], options);
         }
 
         public async Task Start()

--- a/RockyBus/IMessageTransport.cs
+++ b/RockyBus/IMessageTransport.cs
@@ -12,7 +12,9 @@ namespace RockyBus
         Task InitializeReceivingEndpoint();
 
         Task Publish<T>(T message, string messageTypeName);
+        Task Publish<T>(T message, string messageTypeName, PublishOptions options);
         Task Send<T>(T message, string messageTypeName);
+        Task Send<T>(T message, string messageTypeName, SendOptions options);
 
         Task StartReceivingMessages(MessageHandlerExecutor messageHandlerExecutor);
         Task StopReceivingMessages();

--- a/RockyBus/OptionExtensions.cs
+++ b/RockyBus/OptionExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace RockyBus
+{
+    public static class OptionExtensions
+    {
+        public static void SetHeaders(this Options options, string key, string value)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException("options", "Options cannot be null.");
+            }
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException("key", "Key cannot be null or empty.");
+            }
+
+            options.Headers[key] = value;
+        }
+
+        public static IReadOnlyDictionary<string, string> GetHeaders(this Options options)
+        {
+            return new ReadOnlyDictionary<string, string>(options.Headers);
+        }
+    }
+}


### PR DESCRIPTION
Add publish and send overloads with options so users can optionally add user defined properties to the message header when sending or publishing from the bus.