### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/DependencyResolvers/RockyBus.Microsoft.Extensions.DependencyInjection/RockyBus.Microsoft.Extensions.DependencyInjection.csproj
+++ b/DependencyResolvers/RockyBus.Microsoft.Extensions.DependencyInjection/RockyBus.Microsoft.Extensions.DependencyInjection.csproj
@@ -11,7 +11,15 @@
     <Copyright>Copyright 2017 RockyBus</Copyright>
     <PackageTags>RockyBus</PackageTags>
     <PackageProjectUrl>https://github.com/longility/RockyBus</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\RockyBus\RockyBus.csproj" />

--- a/MessageTransports/RockyBus.Azure.ServiceBus/RockyBus.Azure.ServiceBus.csproj
+++ b/MessageTransports/RockyBus.Azure.ServiceBus/RockyBus.Azure.ServiceBus.csproj
@@ -11,7 +11,15 @@
     <Copyright>Copyright 2017 RockyBus</Copyright>
     <PackageTags>RockyBus</PackageTags>
     <PackageProjectUrl>https://github.com/longility/RockyBus</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/MessageTransports/RockyBus.Azure.Storage.Queue/RockyBus.Azure.Storage.Queue.csproj
+++ b/MessageTransports/RockyBus.Azure.Storage.Queue/RockyBus.Azure.Storage.Queue.csproj
@@ -11,7 +11,15 @@
     <Copyright>Copyright 2019 RockyBus</Copyright>
     <PackageTags>RockyBus</PackageTags>
     <PackageProjectUrl>https://github.com/longility/RockyBus</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\RockyBus\RockyBus.csproj" />

--- a/RockyBus.Abstractions/RockyBus.Abstractions.csproj
+++ b/RockyBus.Abstractions/RockyBus.Abstractions.csproj
@@ -11,6 +11,14 @@
     <Copyright>Copyright 2017 RockyBus</Copyright>
     <PackageTags>RockyBus</PackageTags>
     <PackageProjectUrl>https://github.com/longility/RockyBus</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 </Project>

--- a/RockyBus/RockyBus.csproj
+++ b/RockyBus/RockyBus.csproj
@@ -11,7 +11,15 @@
     <Copyright>Copyright 2017 RockyBus</Copyright>
     <PackageTags>RockyBus</PackageTags>
     <PackageProjectUrl>https://github.com/longility/RockyBus</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\RockyBus.Abstractions\RockyBus.Abstractions.csproj" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
