### PR TITLE
Conditional clear event message filter

### DIFF
--- a/MessageTransports/RockyBus.Azure.ServiceBus/ReceivingEndpoint.cs
+++ b/MessageTransports/RockyBus.Azure.ServiceBus/ReceivingEndpoint.cs
@@ -159,7 +159,7 @@ namespace RockyBus.Azure.ServiceBus
         async Task<bool> IsDelta(IEnumerable<Rule> eventMessageTypes)
         {
             var existingMessageRules = await GetExistingRules();
-            // Existing message rules has command message filter, so need to remove before comparing
+            // Existing message rules have command message filter, so need to remove before comparing
             var existingMessageRulesCount = existingMessageRules.Any() ? existingMessageRules.Count() - 1 : 0;
             return eventMessageTypes.Count() != existingMessageRulesCount;
         }

--- a/MessageTransports/RockyBus.Azure.ServiceBus/ReceivingEndpoint.cs
+++ b/MessageTransports/RockyBus.Azure.ServiceBus/ReceivingEndpoint.cs
@@ -41,7 +41,7 @@ namespace RockyBus.Azure.ServiceBus
             string name = nameof(eventMessageFilter);
             foreach (var r in eventMessageFilter)
             {
-                var evtName = counter > 1 ? $"{name} {counter.ToString()}" : name;
+                var evtName = counter > 1 ? $"{name}{counter.ToString()}" : name;
                 await CreateOrUpdateRule(evtName, r).ConfigureAwait(false);
                 counter++;
             }

--- a/MessageTransports/RockyBus.Azure.ServiceBus/Retry.cs
+++ b/MessageTransports/RockyBus.Azure.ServiceBus/Retry.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace RockyBus.Azure.ServiceBus


### PR DESCRIPTION
Some listeners are losing messages when deleting the event message filters on Startup.  With this PR the event message filters will only be deleted if the number of rules are less than the existing number of rules.